### PR TITLE
RuntimeError: dictionary changed size during iteration

### DIFF
--- a/nicegui/outbox.py
+++ b/nicegui/outbox.py
@@ -48,11 +48,10 @@ async def loop(air: Optional[Air]) -> None:
 
         coros = []
         try:
-            update_queue_items = list(update_queue.items())
-            for client_id, elements in update_queue_items:
+            for client_id, elements in update_queue.items():
                 data = {
                     element_id: None if element is None else element._to_dict()  # pylint: disable=protected-access
-                    for element_id, element in elements.items()
+                    for element_id, element in list(elements.items())
                 }
                 coros.append(emit('update', data, client_id))
             update_queue.clear()


### PR DESCRIPTION
This issue happen few or more times in a hour.  Now after that change program has been running without issue many hours.  This is very hard to reproduce as it come as a side effect of sort of big program running.

List of items is essentially copy so therefore cannot change during the iteration.

Here is error message:

RuntimeError: dictionary changed size during iteration binding propagation for 17 active links took 0.011 s dictionary changed size during iteration
Traceback (most recent call last):
  File "/home/hsyrja/.local/lib/python3.10/site-packages/nicegui/outbox.py", line 49, in loop
    data = {
  File "/home/hsyrja/.local/lib/python3.10/site-packages/nicegui/outbox.py", line 49, in <dictcomp>
    data = {
RuntimeError: dictionary changed size during iteration